### PR TITLE
fix: heap buffer overflow in paired_t_test with unbalanced groups

### DIFF
--- a/src/modelling_functions.c
+++ b/src/modelling_functions.c
@@ -60,8 +60,10 @@ SEXP paired_t_test(SEXP voxel, SEXP grouping) {
   PROTECT(output=allocVector(REALSXP, 1));
   t = REAL(output);
 
-  group0 = malloc(sizeof(double) * n2);
-  group1 = malloc(sizeof(double) * n2);
+  /* allocate n elements per group: the grouping vector is not guaranteed
+   * to be perfectly balanced, so count0 or count1 may reach up to n */
+  group0 = malloc(sizeof(double) * n);
+  group1 = malloc(sizeof(double) * n);
 
   count0 = 0;
   count1 = 0;


### PR DESCRIPTION
Fixes #6.

`paired_t_test` in `src/modelling_functions.c` allocates `n/2` elements for each group buffer, but the loop that distributes voxels into `group0`/`group1` does no bounds checking. If the grouping vector is not perfectly balanced (e.g. all values 0), `count0` or `count1` exceeds `n/2` and writes past the allocation.

This allocates `n` elements per buffer, which bounds the worst case safely. Behaviour is unchanged for balanced inputs (the existing `n2`-based statistics loop still runs over the first `n/2` matched pairs).